### PR TITLE
Support for Ruby 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 vendor/
 .rbx
 .rvmrc
+*.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ before_install:
 install: "bundle install"
 script: "bundle exec rake"
 rvm:
+  - 2.0.0
   - 2.1.0
   - 2.2.0
   - 2.3.0
   - 2.4.0
-

--- a/logging-journald.gemspec
+++ b/logging-journald.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'journald-logger'
   spec.add_runtime_dependency 'logging'


### PR DESCRIPTION
Unfortunately, journald-logger requires Ruby 2.1+ and this will fail.